### PR TITLE
Fix OOM crash: cap unbounded exec output buffering

### DIFF
--- a/src/remote/connection-pool.ts
+++ b/src/remote/connection-pool.ts
@@ -26,6 +26,16 @@ interface PooledConnection {
   lastError?: string;
 }
 
+/** Max characters to buffer from a single command's stdout or stderr. */
+const MAX_EXEC_OUTPUT = 512 * 1024; // 512 KB
+
+function capOutput(str: string, max: number): string {
+  if (str.length <= max) return str;
+  const half = Math.floor(max / 2) - 40;
+  const omitted = str.length - max + 80;
+  return str.slice(0, half) + `\n\n... [${omitted} characters omitted] ...\n\n` + str.slice(-half);
+}
+
 export class ConnectionPool {
   private connections = new Map<string, PooledConnection>();
   private machines = new Map<string, RemoteMachine>();
@@ -146,18 +156,32 @@ export class ConnectionPool {
 
         let stdout = "";
         let stderr = "";
+        let stdoutCapped = false;
+        let stderrCapped = false;
 
         stream.on("data", (data: Buffer) => {
+          if (stdoutCapped) return;
           stdout += data.toString();
+          if (stdout.length > MAX_EXEC_OUTPUT) {
+            stdoutCapped = true;
+          }
         });
         stream.stderr.on("data", (data: Buffer) => {
+          if (stderrCapped) return;
           stderr += data.toString();
+          if (stderr.length > MAX_EXEC_OUTPUT) {
+            stderrCapped = true;
+          }
         });
         stream.on("error", (streamErr: Error) => {
           reject(streamErr);
         });
         stream.on("close", (code: number) => {
-          resolve({ stdout, stderr, exitCode: code ?? 0 });
+          resolve({
+            stdout: capOutput(stdout, MAX_EXEC_OUTPUT),
+            stderr: capOutput(stderr, MAX_EXEC_OUTPUT),
+            exitCode: code ?? 0,
+          });
         });
       });
     });
@@ -165,7 +189,7 @@ export class ConnectionPool {
 
   private execLocal(command: string, timeoutMs = 300_000): Promise<ExecResult> {
     return new Promise((resolve) => {
-      cpExec(command, { maxBuffer: 10 * 1024 * 1024, timeout: timeoutMs, shell: "/bin/bash" }, (err, stdout, stderr) => {
+      cpExec(command, { maxBuffer: MAX_EXEC_OUTPUT + 1024, timeout: timeoutMs, shell: "/bin/bash" }, (err, stdout, stderr) => {
         let exitCode = 0;
         if (err) {
           // err.code can be number (exit code), string (error code like ETIMEDOUT), or null (signal kill)
@@ -179,8 +203,8 @@ export class ConnectionPool {
           }
         }
         resolve({
-          stdout: stdout ?? "",
-          stderr: stderr ?? "",
+          stdout: capOutput(stdout ?? "", MAX_EXEC_OUTPUT),
+          stderr: capOutput(stderr ?? "", MAX_EXEC_OUTPUT),
           exitCode,
         });
       });


### PR DESCRIPTION
Hi there, like what you're doing here. Was curious to try it out, ran for a few hours, many experiments in parallel. After a few hours I got an OOM exception:

```
<--- Last few GCs --->

[182929:0x42067000] 9097967 ms: Scavenge (reduce) (interleaved) 4078.5 (4087.9) -> 4077.5 (4087.9) MB, pooled: 0 MB, 10.81 / 0.00 ms (average mu = 0.193, current mu = 0.078) allocation failure;
[182929:0x42067000] 9098101 ms: Mark-Compact (reduce) 4078.4 (4087.9) -> 4076.7 (4087.9) MB, pooled: 0 MB, 58.66 / 0.05 ms (+ 1839.3 ms in 0 steps since start of marking, biggest step 0.0 ms, walltime since start of marking 2668 ms) (average mu = 0.297, current mu = 0.078)

<--- JS stacktrace --->

FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
----- Native stack trace -----

1: 0xe98a91 node::OOMErrorHandler(char const*, v8::OOMDetails const&) [node]
2: 0x12a7710 v8::Utils::ReportOOMFailure(v8::internal::Isolate*, char const*, v8::OOMDetails const&) [node]
3: 0x12a7aac v8::internal::V8::FatalProcessOutOfMemory(v8::internal::Isolate*, char const*, v8::OOMDetails const&) [node]
4: 0x150a9e5 [node]
5: 0x150aa12 [node]
6: 0x151d7ea [node]
7: 0x15217e0 [node]
8: 0x1fab171 [node]

zsh: abort (core dumped) helios
```

**Machine**: Ubuntu 24.04.3 LTS, running Helios in CLI mode with Claude Opus 4.6

--- 

Not being an expert in TypeScript, but I seem to have honed down the error down to [these](https://github.com/snoglobe/helios/blob/5c6cda2aadac595b9e3f1a4d398f4a8aedf50a1d/src/remote/connection-pool.ts#L150:L155) set of lines in `connection-pool.ts`

```
 stream.on("data", (data: Buffer) => {
          stdout += data.toString();
        });
```

I think this is what transpired my OOM error.  The SSH exec buffers stdout/stderr into JS strings with no limit. When having long sessions, commands producing large output (training logs, file dumps) accumulate in the Claude Agent SDK's conversation state and eventually exhaust the heap.

The suggested fix caps stdout/stderr at 512KB per command, middle-truncating preserving head and tail. Local exec `maxBuffer` reduced from 10MB to match. 

No data written to disk by commands is affected. Thus `read_file` and `task_output` tools should still work as expected. 

Currently testing this fix locally, have not encountered the OOM issue yet.